### PR TITLE
Link env conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ is called (unless you name your default git branch 'production')
 If any of the entries are bracketed by //, then the value is assumed
 to be a regular expression.
 
+Matching happens against dir names as well as branch names so be sure that
+translation doesn't bite you. For example setting:
+
+  some/thing
+
+will match branch `some/thing` but not the folder some__thing.
+
 For example, the setting:
 
   production,/^foobar/

--- a/agent/puppetupdate.ddl
+++ b/agent/puppetupdate.ddl
@@ -28,8 +28,8 @@ action "update", :description => "Update the branch to a specific revision" do
     :maxlength   => 255
 
   input :cleanup,
-    :description => "cleanup old branches",
-    :display_as  => "cleanup old branches after updating",
+    :description => "cleanup old branches [deprecated]",
+    :display_as  => "cleanup old branches after updating [deprecated]",
     :optional    => true,
     :type        => :string,
     :prompt      => "Cleanup (yes/no)",

--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -83,7 +83,9 @@ module MCollective
       def update_all_branches
         whilst_locked do
           update_bare_repo
-          git_branches.each { |branch| update_branch(branch) }
+          git_branches.reject do |branch|
+            remove_branches.select { |b| b.match(branch) }.count > 0
+          end.each {|branch| update_branch(branch) }
           cleanup_old_branches
         end
       end

--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -65,9 +65,9 @@ module MCollective
 
       def strip_ignored_branches(branch_list)
         branch_list.reject do |branch|
-          branch == '(no branch)' ||
-            branch =~ /detached from/ ||
-            ignore_branches.select { |b| b.match(branch) }.count > 0
+          branch == '(no branch)' or
+          branch =~ /detached from/ or
+          ignore_branches.select { |b| b.match(branch) }.count > 0
         end
       end
 

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -1,7 +1,6 @@
 #! /usr/bin/env ruby -S rspec
 $: << '.'
 require 'singleton'
-require 'mcollective'
 require 'mcollective/logger'
 require 'mcollective/log'
 require 'mcollective/config'

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -43,7 +43,7 @@ describe MCollective::Agent::Puppetupdate do
         echo 'hi' > file3
         git add file3
         git commit -am"must_be_hidden";
-        git push origin must_be_hidden) >/dev/null
+        git push -q origin must_be_hidden) >/dev/null
     SHELL
 
     agent.dir      = Dir.mktmpdir
@@ -54,11 +54,14 @@ describe MCollective::Agent::Puppetupdate do
     clean
     clone_main
     clone_bare
+    Dir.mkdir(agent.env_dir)
+
     agent.update_all_branches
   end
 
-  it "#strip_ignored_branches works" do
-    agent.strip_ignored_branches(%w(foo bar leave_me_alone)).should == %w(foo bar)
+  it "#branches_in_repo_to_sync works" do
+    agent.stubs(:branches_in_repo => ['foo', 'bar', 'leave_me_alone'])
+    agent.branches_in_repo_to_sync.should == ['foo', 'bar']
   end
 
   it "#git_dir should depend on config" do
@@ -67,11 +70,12 @@ describe MCollective::Agent::Puppetupdate do
   end
 
   it "#branch_dir is not using reserved branch" do
-    agent.branch_dir('foobar').should == 'foobar'
-    agent.branch_dir('master').should == 'masterbranch'
-    agent.branch_dir('user').should   == 'userbranch'
-    agent.branch_dir('agent').should  == 'agentbranch'
-    agent.branch_dir('main').should   == 'mainbranch'
+    agent.branch_dir('fo/bar').should eq('fo__bar')
+    agent.branch_dir('foobar').should eq('foobar')
+    agent.branch_dir('master').should eq('masterbranch')
+    agent.branch_dir('user').should   eq('userbranch')
+    agent.branch_dir('agent').should  eq('agentbranch')
+    agent.branch_dir('main').should   eq('mainbranch')
   end
 
   describe "#update_bare_repo" do
@@ -80,34 +84,34 @@ describe MCollective::Agent::Puppetupdate do
     it "clones fresh repository" do
       agent.update_bare_repo
       File.directory?(agent.git_dir).should be true
-      agent.git_branches.size.should be > 1
+      agent.branches_in_repo.size.should be > 1
     end
 
     it "fetches repository when present" do
       clone_bare
       agent.update_bare_repo
       File.directory?(agent.git_dir).should be true
-      agent.git_branches.size.should be > 1
+      agent.branches_in_repo.size.should be > 1
     end
   end
 
-  it '#cleanup_old_branches removes branches no longer in repo' do
+  it '#drop_bad_dirs removes branches no longer in repo' do
     `mkdir -p #{agent.env_dir}/hahah`
-    agent.cleanup_old_branches
+    agent.drop_bad_dirs
     File.exist?("#{agent.env_dir}/hahah").should == false
     File.exist?("#{agent.env_dir}/masterbranch").should == true
   end
 
-  it '#cleanup_old_branches does not remove ignored branches' do
+  it '#drop_bad_dirs does not remove ignored branches' do
     `mkdir -p #{agent.env_dir}/leave_me_alone`
-    agent.cleanup_old_branches
+    agent.drop_bad_dirs
     File.exist?("#{agent.env_dir}/leave_me_alone").should == true
   end
 
-  it '#cleanup_old_branches does cleanup removed branches' do
+  it '#drop_bad_dirs does cleanup removed branches' do
     File.exist?("#{agent.env_dir}/must_be_hidden").should == false
     `mkdir -p #{agent.env_dir}/must_be_hidden`
-    agent.cleanup_old_branches
+    agent.drop_bad_dirs
     File.exist?("#{agent.env_dir}/must_be_hidden").should == false
   end
 
@@ -118,25 +122,11 @@ describe MCollective::Agent::Puppetupdate do
     File.exist?("#{agent.env_dir}/masterbranch/puppet.conf.base").should == false
   end
 
-  describe '#cleanup_old_branches' do
+  describe '#drop_bad_dirs' do
     it 'cleans up by default' do
       agent.expects(:run)
       `mkdir -p #{agent.env_dir}/hahah`
-      agent.cleanup_old_branches
-    end
-
-    it 'cleans up with yes/1/true' do
-      %w(yes 1 true).each do |value|
-        agent.expects(:run)
-        `mkdir -p #{agent.env_dir}/hahah`
-        agent.cleanup_old_branches(value)
-      end
-    end
-
-    it 'does not cleanup otherwise' do
-      agent.expects(:run).never
-      `mkdir -p #{agent.env_dir}/hahah`
-      agent.cleanup_old_branches('no')
+      agent.drop_bad_dirs
     end
   end
 
@@ -145,15 +135,15 @@ describe MCollective::Agent::Puppetupdate do
       new_branch 'testing_del_branch'
       agent.update_bare_repo
       agent.update_branch 'testing_del_branch'
-      agent.env_branches.include?('testing_del_branch').should == true
+      agent.dirs_in_env_dir.include?('testing_del_branch').should == true
 
       del_branch 'testing_del_branch'
       agent.update_bare_repo
-      agent.env_branches.include?('testing_del_branch').should == true
+      agent.dirs_in_env_dir.include?('testing_del_branch').should == true
 
       agent.update_branch 'testing_del_branch'
-      agent.cleanup_old_branches
-      agent.env_branches.include?('testing_del_branch').should == false
+      agent.drop_bad_dirs
+      agent.dirs_in_env_dir.include?('testing_del_branch').should == false
     end
   end
 
@@ -173,11 +163,11 @@ describe MCollective::Agent::Puppetupdate do
   end
 
   def clone_main
-    `git clone #{agent.repo_url} #{agent.dir}`
+    `git clone -q #{agent.repo_url} #{agent.dir}`
   end
 
   def clone_bare
-    `git clone --mirror #{agent.repo_url} #{agent.git_dir}`
+    `git clone -q --mirror #{agent.repo_url} #{agent.git_dir}`
   end
 
   def new_branch(name)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,7 @@ require 'mocha'
 require 'tempfile'
 
 module MCollective::Test::Util::Validator
-  def self.validate
-    false
-  end
+  def self.validate; false; end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
modulepath in puppet 3.7 is deprecated and in 3.7.4 generates critical error, it's value however doesn't really change between environments

this pr allows linking environment.conf from global confdir into each env folder
